### PR TITLE
mplement data-driven wave progression with upgrade-between-waves flow, stacked upgrade balancing/UI/input fixes, and visual/gameplay polish for backgrounds and on-screen enemy bounds.

### DIFF
--- a/highscore.json
+++ b/highscore.json
@@ -1,1 +1,1 @@
-{"high_score": 0}
+{"high_score": 24}

--- a/level_data.json
+++ b/level_data.json
@@ -36,7 +36,7 @@
    
    "second_level": {
       "level_num": 3,
-      "bg_img":    "background_test.png",
+      "bg_img":    "background_asteroids.png",
       "waves": [
          {
             "enemy_type":   "Basic_Enemy",

--- a/states/game_state.py
+++ b/states/game_state.py
@@ -1,11 +1,10 @@
 import pygame
 import os
-import random
 from states import settings
 from states import utils
+from states import entities
 from states.base_state import State
 from states.death_state import DeathState  #ADDED: death screen
-from states import entities
 from states.upgrade_state import UpgradeState
 
 # assets folder is at repo root
@@ -20,6 +19,10 @@ class GameState(State):
         pygame.init()
         pygame.mixer.init(devicename="pygame.mixer.get_dev_info()")
         
+        # reset upgrade-tuned stats at run start
+        settings.BULLET_SPEED = settings.DEFAULT_BULLET_SPEED
+        settings.BULLET_COOLDOWN = settings.DEFAULT_BULLET_COOLDOWN
+
         # Sets the background color, and draws the image
         self.bg_color = (0, 0, 0)
         bg_name = "background_asteroids.png"
@@ -38,42 +41,25 @@ class GameState(State):
         if hasattr(app, "testing") and app.testing:
             self.countdown_active = False
 
-        # Spawning Enemies
+        # progression state
+        self.level_sequence = utils.get_level_sequence()
+        if not self.level_sequence:
+            raise ValueError("No levels found in level_data.json")
+        self.level_index = 0
+        self.current_level_name = self.level_sequence[self.level_index]
+        self.current_level_data = utils.load_level(self.current_level_name)
+        self.current_wave_index = 0
+        self.pending_level_index = None
+        self.pending_wave_index = None
+        self.waiting_for_upgrade = False
+
+        # spawn first wave of first level
         self.enemy_ships.empty()
-
-        # Loading Level Data
         self.bg_image = utils.build_level(
-            level_name="first_level",
+            level_name=self.current_level_name,
             enemy_ships=self.enemy_ships,
-            temp_type=entities.Basic_Enemy
+            wave_index=self.current_wave_index
         )
-        num_enemies = 10
-        columns = num_enemies
-
-        spacing_x = app.width // columns
-
-        for i in range(num_enemies):
-            # base position in column
-            x = i * spacing_x + spacing_x // 2
-
-            # add small randomness so it's not perfectly aligned
-            x += random.randint(-20, 20)
-
-            # spawn in top 1/4
-            y = random.randint(0, app.height // 4)
-
-            enemy = entities.Basic_Enemy(
-                frames=utils.load_spritesheet(
-                    sheet_name="enemy_basic.png",
-                    frame_width=utils.FRAME_SIZE,
-                    frame_height=utils.FRAME_SIZE
-                ),
-                start_pos=(x, y)
-            )
-
-            self.enemy_ships.add(enemy)
-
-
 
         # Spawning Player
         player_speed = 5
@@ -96,6 +82,36 @@ class GameState(State):
         if GameState.saved_player_position is not None:
             self.player.rect.center = GameState.saved_player_position
 
+    def _resume_after_upgrade(self):
+        if self.pending_level_index is not None:
+            self.level_index = self.pending_level_index
+            self.current_level_name = self.level_sequence[self.level_index]
+            self.current_level_data = utils.load_level(self.current_level_name)
+
+        if self.pending_wave_index is not None:
+            self.current_wave_index = self.pending_wave_index
+
+        self.pending_level_index = None
+        self.pending_wave_index = None
+        self.waiting_for_upgrade = False
+
+        # reset projectiles between waves so transitions are fair
+        self.enemy_ships.empty()
+        self.enemy_bullets.empty()
+        self.ally_bullets.empty()
+        self.bg_image = utils.build_level(
+            level_name=self.current_level_name,
+            enemy_ships=self.enemy_ships,
+            wave_index=self.current_wave_index
+        )
+
+        # short countdown before next wave starts
+        self.countdown = 1.5
+        self.countdown_active = True
+
+    def on_upgrade_complete(self):
+        self._resume_after_upgrade()
+
     def handle_event(self, app, event):
         if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
             # Save player position before pausing
@@ -105,6 +121,9 @@ class GameState(State):
 
                 # Keybind to quickly debug something
         if event.type == pygame.KEYDOWN and event.key == pygame.K_t:
+            self.waiting_for_upgrade = True
+            self.pending_level_index = self.level_index
+            self.pending_wave_index = self.current_wave_index
             app.change_state(UpgradeState(app, self))
         
         # Shooting input
@@ -129,6 +148,8 @@ class GameState(State):
 
         player_pos = (self.player.rect.x, self.player.rect.y)
         self.enemy_ships.update(player_pos=player_pos)
+        for enemy in self.enemy_ships:
+            enemy.rect.clamp_ip(play_area)
 
         # Enemy auto-fire logic for basic enemies
         for enemy in self.enemy_ships:
@@ -191,6 +212,27 @@ class GameState(State):
             pygame.mixer.Sound.play(sfx_boom)
             self.enemy_hit_count += len(collisions)
 
+        # Wave progression: clear wave -> upgrade pick -> spawn next wave/level
+        if not self.enemy_ships and not self.waiting_for_upgrade:
+            total_waves = len(self.current_level_data["waves"])
+            is_last_wave = self.current_wave_index >= total_waves - 1
+            is_last_level = self.level_index >= len(self.level_sequence) - 1
+
+            if is_last_wave and is_last_level:
+                app.change_state(DeathState("You Win!", self.enemy_hit_count))
+                return
+
+            self.waiting_for_upgrade = True
+            if not is_last_wave:
+                self.pending_level_index = self.level_index
+                self.pending_wave_index = self.current_wave_index + 1
+            else:
+                self.pending_level_index = self.level_index + 1
+                self.pending_wave_index = 0
+
+            app.change_state(UpgradeState(app, self))
+            return
+
 
     def draw(self, app, screen):
         screen.fill(self.bg_color)
@@ -236,6 +278,12 @@ class GameState(State):
         font = pygame.font.Font(None, 36)
         counter_text = font.render(f"Hits: {self.enemy_hit_count}", True, (255, 255, 255))
         screen.blit(counter_text, (10, 10))
+        level_text = font.render(
+            f"Level: {self.current_level_data['level_num']}  Wave: {self.current_wave_index + 1}/{len(self.current_level_data['waves'])}",
+            True,
+            (255, 255, 255)
+        )
+        screen.blit(level_text, (10, 45))
         font = pygame.font.Font("assets/fonts/PressStart2P-vaV7.ttf", 20)
 
         for i in range(self.lives):

--- a/states/settings.py
+++ b/states/settings.py
@@ -28,5 +28,9 @@ WAVE_CORNER_X = 120
 WAVE_CORNER_Y = 120
 
 # Bullet settings
-BULLET_SPEED = 8
-BULLET_COOLDOWN = 0.2  # seconds between shots
+DEFAULT_BULLET_SPEED = 8
+DEFAULT_BULLET_COOLDOWN = 0.2  # seconds between shots
+
+# runtime-tuned by upgrades
+BULLET_SPEED = DEFAULT_BULLET_SPEED
+BULLET_COOLDOWN = DEFAULT_BULLET_COOLDOWN

--- a/states/upgrade_state.py
+++ b/states/upgrade_state.py
@@ -1,9 +1,7 @@
 
 import pygame
 from states.base_state import State
-from states.main_menu_state import MainMenuState
 from states import settings
-from states import utils
 
 class UpgradeState(State):
     def __init__(self, app, previous_state):
@@ -11,10 +9,11 @@ class UpgradeState(State):
 
     def on_enter(self, app):
         self.font = pygame.font.Font("assets/fonts/PressStart2P-vaV7.ttf", 32)
-        self.small_font = pygame.font.Font("assets/fonts/PressStart2P-vaV7.ttf", 24)
+        self.small_font = pygame.font.Font("assets/fonts/PressStart2P-vaV7.ttf", 20)
+        self.tiny_font = pygame.font.Font("assets/fonts/PressStart2P-vaV7.ttf", 16)
 
         self.selected = 0
-        self.options = ["Faster Bullet Speed", "Faster Cooldown"]
+        self.options = ["Bullet Speed +2", "Fire Rate +10%"]
 
     def handle_event(self, app, event):
         sfx_menu = pygame.mixer.Sound("assets/sfx/menu1.wav")
@@ -23,15 +22,20 @@ class UpgradeState(State):
             if event.key in (pygame.K_UP, pygame.K_DOWN):
                 self.selected = (self.selected + 1) % 2
                 pygame.mixer.Sound.play(sfx_menu)
-            elif event.key == pygame.K_RETURN or event.key == pygame.K_SPACE:
+            elif event.key == pygame.K_RETURN:
                 if self.selected == 0:
-                    settings.BULLET_SPEED = 15
-                    app.change_state(self.previous_state)
+                    settings.BULLET_SPEED = min(25, settings.BULLET_SPEED + 2)
+                    self._resume_previous_state(app)
                 else:
-                    settings.BULLET_COOLDOWN = 0.1
-                    app.change_state(self.previous_state)
+                    settings.BULLET_COOLDOWN = max(0.05, settings.BULLET_COOLDOWN * 0.9)
+                    self._resume_previous_state(app)
             elif event.key == pygame.K_ESCAPE:
-                app.change_state(self.previous_state)
+                self._resume_previous_state(app)
+
+    def _resume_previous_state(self, app):
+        if hasattr(self.previous_state, "on_upgrade_complete"):
+            self.previous_state.on_upgrade_complete()
+        app.state = self.previous_state
 
     def update(self, app, dt):
         pass
@@ -46,13 +50,21 @@ class UpgradeState(State):
         screen.blit(overlay, (0, 0))
 
         text = self.font.render("Choose an Upgrade:", True, (255, 255, 255))
-        rect = text.get_rect(center=(settings.WIDTH // 2, settings.HEIGHT // 2 - 80))
+        rect = text.get_rect(center=(settings.WIDTH // 2, settings.HEIGHT // 2 - 100))
         screen.blit(text, rect)
+
+        stats_text = self.tiny_font.render(
+            f"bullet speed: {settings.BULLET_SPEED}   cooldown: {settings.BULLET_COOLDOWN:.2f}s",
+            True,
+            (200, 200, 200)
+        )
+        stats_rect = stats_text.get_rect(center=(settings.WIDTH // 2, settings.HEIGHT // 2 - 20))
+        screen.blit(stats_text, stats_rect)
 
         for i, option in enumerate(self.options):
 
             color = (255, 255, 0) if i == self.selected else (180, 180, 180)
             opt = self.small_font.render(option, True, color)
 
-            opt_rect = opt.get_rect(center=(settings.WIDTH // 2, settings.HEIGHT // 2 + (i * 60)))
+            opt_rect = opt.get_rect(center=(settings.WIDTH // 2, settings.HEIGHT // 2 + 55 + (i * 60)))
             screen.blit(opt, opt_rect)

--- a/states/utils.py
+++ b/states/utils.py
@@ -1,6 +1,8 @@
 import pygame
 import os
 import json
+from typing import Type
+from states import settings
 
 # This exists to key out spritesheet backgrounds
 SHEET_BG = (160, 200, 152)
@@ -63,6 +65,28 @@ def load_level(level_name):
     except (FileNotFoundError, json.JSONDecodeError, KeyError):
         return 0
 
+def load_all_levels():
+    try:
+        with open(LEVEL_DATA, "r") as file:
+            data = json.load(file)
+            return data if isinstance(data, dict) else {}
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+def get_level_sequence():
+    levels = load_all_levels()
+    # Skip test/debug levels from normal progression flow.
+    playable_levels = {
+        level_name: level_data
+        for level_name, level_data in levels.items()
+        if "test" not in level_name.lower()
+    }
+    sorted_levels = sorted(
+        playable_levels.items(),
+        key=lambda item: item[1].get("level_num", 999999)
+    )
+    return [level_name for level_name, _ in sorted_levels]
+
 def spawn_enemy_wave(enemy_type, enemy_group, frames, corner_pos, size, spacing):
     for j in range(size[1]):     # Rows
             for i in range(size[0]): # Columns
@@ -71,33 +95,53 @@ def spawn_enemy_wave(enemy_type, enemy_group, frames, corner_pos, size, spacing)
                     corner_pos[1] + j * spacing[1]
                 )
                 enemy = enemy_type(frames=frames, start_pos=(x, y))
+                enemy.rect.clamp_ip(pygame.Rect(0, 0, settings.WIDTH, settings.HEIGHT))
                 enemy_group.add(enemy)
 
-def build_level(level_name, enemy_ships, temp_type):
+def build_level(level_name, enemy_ships, wave_index=None):
     # Loads the data for one level as a python dictionary
     level = load_level(level_name=level_name)
+    if not level:
+        raise ValueError(f"Unknown level: {level_name}")
 
     # Loads the background image named in level_data into a pygame image
     bg_image = pygame.image.load(os.path.join(asset_folder, level["bg_img"]))
-    
-    #needs to parse enemy types from level_data somehow
 
-    # Spawns enemy waves
-    # Loops for however many waves there are
-    for wav_index in range(len(level["waves"])):
-        
-        
+    # Import locally to avoid circular imports (entities -> utils for spritesheets)
+    from states import entities
+
+    enemy_type_map: dict[str, Type[pygame.sprite.Sprite]] = {
+        "Basic_Enemy": entities.Basic_Enemy,
+        "Swarm_Enemy": entities.Swarm_Enemy,
+        "Bomber_Enemy": entities.Bomber_Enemy,
+    }
+
+    # Spawns enemy waves (or one specific wave when wave_index is set)
+    if wave_index is None:
+        waves_to_spawn = level["waves"]
+    else:
+        waves = level["waves"]
+        if wave_index < 0 or wave_index >= len(waves):
+            raise ValueError(f"Wave index {wave_index} out of range for level '{level_name}'")
+        waves_to_spawn = [waves[wave_index]]
+
+    for wave in waves_to_spawn:
+        enemy_type_name = wave.get("enemy_type")
+        enemy_type = enemy_type_map.get(enemy_type_name)
+        if enemy_type is None:
+            raise ValueError(f"Unknown enemy_type '{enemy_type_name}' in level '{level_name}'")
+
         spawn_enemy_wave(
-            enemy_type=temp_type,
+            enemy_type=enemy_type,
             enemy_group=enemy_ships,
             frames=load_spritesheet(
-                sheet_name=level["waves"][wav_index]["sprite_sheet"],
+                sheet_name=wave["sprite_sheet"],
                 frame_width=66,
                 frame_height=FRAME_SIZE
             ),
-            corner_pos=level["waves"][wav_index]["wave_position"],
-            size=level["waves"][wav_index]["wave_size"],
-            spacing=level["waves"][wav_index]["wave_spacing"]
+            corner_pos=wave["wave_position"],
+            size=wave["wave_size"],
+            spacing=wave["wave_spacing"]
         )
     
     # Returns the background image name to tie it into level data


### PR DESCRIPTION
- Made levels fully data-driven: enemies now spawn by enemy_type from level_data.json, and removed hardcoded extra enemy spawning.
- Added full progression flow: wave-by-wave advancement, level transitions, upgrade screen between clears, and a final You Win end state.
- Fixed upgrade-state behavior so returning from upgrades resumes the same run (no reset), plus added level/wave HUD info in gameplay.
- Reworked upgrades: now stack each time (speed +2, cooldown -10% with caps), reset to defaults on new run, improved UI spacing/fit, and selection is Enter only.
- Fixed presentation/visibility issues: skipped test levels in normal progression, corrected second-level background to space, and clamped enemy movement/spawn so ships stay onscreen.